### PR TITLE
Adds initial index.yaml

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -1,0 +1,3 @@
+apiVersion: v1
+entries: {}
+generated: 2019-01-31T13:45:06.839687Z


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/5202

Just the output of `helm repo index .` to get the chart repository going.