### PR TITLE
circleci: allow sync job trigger via API

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2
 jobs:
-  lint-scripts:
+  build:
     docker:
       - image: quay.io/giantswarm/shellcheck-alpine:v0.6.0
     steps:
@@ -16,21 +16,3 @@ jobs:
     - run:
         name: Fetch new app releases and rebuild helm chart repository
         command: ci-scripts/build-repository.sh ${CIRCLE_PROJECT_REPONAME} ${PERSONAL_ACCESS_TOKEN}
-
-workflows:
-  version: 2
-
-  lint:
-    jobs:
-      - lint-scripts
-
-  sync:
-    triggers:
-      - schedule:
-          cron: "10,40 * * * *"
-          filters:
-            branches:
-              only:
-                - master
-    jobs:
-      - sync


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/5995

This is a proof-of-concept which validates that we can trigger the control-plane-catalog update via API.

Drawback: CircleCI does not support job trigger via API for config which have workflow defined. This means we have to remove the cron job which triggers the sync job every 30mn.
> - Your workflow does not have to reference the job you triggered with the API
> see https://circleci.com/docs/2.0/api-job-trigger/

```
$ curl -u $(cat ~/secrets/theo/circleci_token): \
    -d 'build_parameters[CIRCLE_JOB]=sync' \
    https://circleci.com/api/v1.1/project/github/giantswarm/control-plane-catalog/tree/circleci/sync-job-trigger
{
  "reponame" : "control-plane-catalog",
  "build_url" : "https://circleci.com/gh/giantswarm/control-plane-catalog/4762",
  "branch" : "circleci/sync-job-trigger",
  ... <content removed> ...
}
```

https://circleci.com/gh/giantswarm/control-plane-catalog/4762
![image](https://user-images.githubusercontent.com/6536819/57535683-ff505000-7342-11e9-8f6c-c36e0b0aa4e4.png)

Note: the job failed here, but that's expected since there was no new release available. All good.