### PR TITLE
Remove badge as there is no Circle integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-[![CircleCI](https://circleci.com/gh/giantswarm/control-plane-catalog.svg?style=shield)](https://circleci.com/gh/giantswarm/control-plane-catalog)
-
 # control-plane-catalog
 
 App Catalog for Giant Swarm control plane services.


### PR DESCRIPTION
Yesterday my brain was a bit fried. I dropped the old Cron based Circle integration but added the badge. 🤦‍♂ 

We are also getting errors because Circle is still trying to build the project. I turn that off in Circle and I think we're done.

If I'm doing something wrong please correct me!